### PR TITLE
Remove unused parameterized dependency from install_requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.2
+  * Bump requests to 2.33.0 (CVE-2026-25645)
+
 # Changelog
 
 ## 0.1.1

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="tap-copper",
-      version="0.1.1",
+      version="0.1.2",
       description="Singer.io tap for extracting data from copper API",
       author="Stitch",
       url="http://singer.io",
@@ -12,7 +12,7 @@ setup(name="tap-copper",
       py_modules=["tap_copper"],
       install_requires=[
         "singer-python==6.1.1",
-        "requests==2.32.4",
+        "requests==2.33.0",
         "backoff==2.2.1",
       ],
       entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(name="tap-copper",
         "singer-python==6.1.1",
         "requests==2.32.4",
         "backoff==2.2.1",
-        "parameterized"
       ],
       entry_points="""
           [console_scripts]


### PR DESCRIPTION
## Summary

`parameterized` is not imported anywhere in this codebase and should not be included in the production image. Removing it from `install_requires`.