### PR TITLE
Fail discovery on invalid Copper credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 0.1.2
   * Bump requests to 2.33.0 for security updates [#15](https://github.com/singer-io/tap-copper/pull/15)
-
+  * Fail discovery on invalid Copper credentials [#16](https://github.com/singer-io/tap-copper/pull/16)
 
 ## 0.1.1
   * Add singer.utils exception handling to main() [#11](https://github.com/singer-io/tap-copper/pull/11)

--- a/tap_copper/__init__.py
+++ b/tap_copper/__init__.py
@@ -32,6 +32,7 @@ def main():
 
     with Client(parsed_args.config) as client:
         if parsed_args.discover:
+            client.check_api_credentials()
             do_discover(config=parsed_args.config)
         elif parsed_args.catalog:
             sync(

--- a/tap_copper/client.py
+++ b/tap_copper/client.py
@@ -139,6 +139,7 @@ class Client:
             if method in ("GET", "POST"):
                 if method == "GET":
                     kwargs.pop("data", None)
+                    kwargs.pop("json", None)
                 response = self._session.request(method, endpoint, **kwargs)
                 raise_for_error(response)
             else:

--- a/tap_copper/client.py
+++ b/tap_copper/client.py
@@ -66,14 +66,14 @@ class Client:
             self.request_timeout = REQUEST_TIMEOUT
 
     def __enter__(self):
-        self.check_api_credentials()
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
         self._session.close()
 
     def check_api_credentials(self) -> None:
-        pass
+        """Validate API credentials with a lightweight authenticated request."""
+        self.make_request("GET", endpoint=f"{self.base_url}/account")
 
     def authenticate(self, headers: Dict, params: Dict) -> Tuple[Dict, Dict]:
         """Attach Copper authentication headers."""

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -251,6 +251,7 @@ def test_check_api_credentials_calls_account_endpoint(monkeypatch, client_cfg):
     args, kwargs = request_calls[0]
     assert args[1] == "GET"
     assert args[2].endswith("/account")
+    assert "json" not in kwargs
 
 
 def test_check_api_credentials_raises_unauthorized(monkeypatch, client_cfg):

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -13,6 +13,7 @@ from tap_copper.exceptions import (
     CopperError,
     CopperRateLimitError,
     CopperServiceUnavailableError,
+    CopperUnauthorizedError,
 )
 
 # ---------------------------------------------------------------------
@@ -231,3 +232,33 @@ def test_empty_string_keys_are_stripped_from_headers_and_params(monkeypatch, cli
         res = client.make_request("GET", "https://example.test",
                                   params={"": "x", "a": 1}, headers={"": "y"})
         assert res == payload
+
+
+def test_check_api_credentials_calls_account_endpoint(monkeypatch, client_cfg):
+    mock_response = make_response(200, {"id": 1})
+    request_calls = []
+
+    def fake_request(*args, **kwargs):
+        request_calls.append((args, kwargs))
+        return mock_response
+
+    monkeypatch.setattr("requests.Session.request", fake_request)
+
+    client = Client(client_cfg)
+    client.check_api_credentials()
+
+    assert len(request_calls) == 1
+    args, kwargs = request_calls[0]
+    assert args[1] == "GET"
+    assert args[2].endswith("/account")
+
+
+def test_check_api_credentials_raises_unauthorized(monkeypatch, client_cfg):
+    monkeypatch.setattr(
+        "requests.Session.request",
+        lambda *_a, **_k: make_response(401, {"message": "Unauthorized"}),
+    )
+
+    client = Client(client_cfg)
+    with pytest.raises(CopperUnauthorizedError):
+        client.check_api_credentials()


### PR DESCRIPTION
## Summary
- Fail fast during discovery when Copper credentials are invalid.
- Align discovery auth flow 

## Problem
A Copper connection could be created successfully, but the first sync failed due to invalid credentials. Discovery did not validate credentials up front, so auth issues surfaced too late.

## Changes
- Added explicit credential validation in discover mode before catalog emission.
  - `client.check_api_credentials()` is now called in the discover branch of `main()`.
- Implemented `Client.check_api_credentials()` with a lightweight authenticated request to `GET /account`.
- Removed implicit auth validation from `Client.__enter__` so discover validation is explicit 
- Added unit tests for:
  - successful credential check endpoint call
  - unauthorized credential failure path

## Validation
- Ran:
  - `PYTHONPATH=. pytest -q tests/unittests/test_client.py`
- Result:
  - `16 passed`

## Impact
- Discovery now fails immediately for invalid credentials.
- Prevents delayed auth failures that previously appeared only at sync time.